### PR TITLE
Fix CS8598 null suppression error

### DIFF
--- a/src/gocore/golib/TypeExtensions.cs
+++ b/src/gocore/golib/TypeExtensions.cs
@@ -311,7 +311,7 @@ namespace go
             Func<Type[], Type> getMethodType;
             List<Type> types = methodInfo.GetParameters().Select(paramInfo => paramInfo.ParameterType).ToList();
 
-            if (delegateType is null!)
+            if (delegateType is null)
             {
                 if (methodInfo.ReturnType == typeof(void))
                 {


### PR DESCRIPTION
Hi, this is just a tiny fix for an issue first seen in #11. The C# compiler got stricter about where it allows the null-suppression operator (`!`), and there is a `!` that breaks the build when using VS 2022 and the .NET 6 SDK:

```
C:\src\go2cs\src\gocore\golib\TypeExtensions.cs(314,33,314,38): error CS8598: The suppression operator is not allowed in this context
```

Guessing this one was missed during [the initial cleanup](https://github.com/GridProtectionAlliance/go2cs/commit/b0262916a66a6b11771462059c1272aeaf3e2afc). Thanks for making go2cs!