### PR TITLE
Update Cayman css to dark mode

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -25,6 +25,12 @@
     <link rel="icon" href="{{ site.baseurl }}/images/go2cs.ico" type="image/x-icon">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="css/octicon.css">
+    {% unless page.light_mode %}
+    <script src="https://cdn.jsdelivr.net/npm/darkreader@4.9.31/darkreader.min.js"></script>
+    <script>
+      DarkReader.enable();
+    </script>
+    {% endunless %}
   </head>
   <body>
     <header class="page-header" role="banner">


### PR DESCRIPTION
## What changed

- Restored the DarkReader hook from the `lewismiddleton/cayman-dark` default layout.
- Preserved the repository's custom navigation, icon, footer, and heading-anchor layout.
- Retained the theme's per-page `light_mode: true` opt-out.

## Why

The remote theme was downloaded successfully, but `docs/_layouts/default.html` overrides the remote theme's layout. Cayman Dark supplies light base CSS and enables dark mode through DarkReader in that overridden layout, so the deployed site remained light.

## Validation

- `git diff --check`
- Confirmed the injected block matches the remote theme's DarkReader integration.
- GitHub Pages should perform the authoritative Jekyll build after merge; Ruby/Jekyll is not installed in the local workspace.
